### PR TITLE
Update Docker and Linux kernel version

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
 <a name="features" class="anchor" href="#features"><span class="octicon octicon-link"></span></a>Features</h2>
 
 <ul>
-<li>Kernel 3.16.4 with AUFS, Docker 1.3.0</li>
+<li>Kernel 3.16.7 with AUFS, Docker 1.3.2</li>
 <li>Container persistence via disk automount on <code>/var/lib/docker</code>
 </li>
 <li>SSH keys persistence via disk automount</li>


### PR DESCRIPTION
Update the version numbers on http://boot2docker.io/ to be in line with those on the releases pages (https://github.com/boot2docker/osx-installer/releases and https://github.com/boot2docker/windows-installer/releases).
